### PR TITLE
Remove redundant local import from handler

### DIFF
--- a/handlers/ua.py
+++ b/handlers/ua.py
@@ -143,8 +143,6 @@ async def class_chosen(call: CallbackQuery, callback_data: ClassCB, state: FSMCo
 @router.callback_query(ConfirmCB.filter(), ChildReg.confirm_child_all)
 async def child_all_confirm(call: CallbackQuery, callback_data: ConfirmCB, state: FSMContext):
     if callback_data.ok == 1:
-        from db.database import get_parent
-
         p = get_parent(call.from_user.id)
         d = await state.get_data()
         if p:


### PR DESCRIPTION
## Summary
- avoid duplicate `get_parent` import inside child confirmation handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bffd47b58083239c81f4f6f55be5eb