### PR TITLE
Refactor order handling into dedicated router and states

### DIFF
--- a/handlers/order.py
+++ b/handlers/order.py
@@ -1,7 +1,6 @@
 from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.state import StatesGroup, State
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from db.database import (
@@ -15,16 +14,9 @@ from keyboards.common import (
     confirm_kb,
     ConfirmCB,
 )
+from states.order_states import OrderStates
 
 router = Router()
-
-
-class OrderStates(StatesGroup):
-    choose_child = State()
-    choosing_week = State()
-    choosing_day = State()
-    choosing_meal = State()
-    confirming = State()
 
 
 WEEKS = [

--- a/states/order_states.py
+++ b/states/order_states.py
@@ -1,0 +1,9 @@
+from aiogram.fsm.state import StatesGroup, State
+
+
+class OrderStates(StatesGroup):
+    choose_child = State()
+    choosing_week = State()
+    choosing_day = State()
+    choosing_meal = State()
+    confirming = State()

--- a/states/ua_states.py
+++ b/states/ua_states.py
@@ -1,16 +1,13 @@
-
 from aiogram.fsm.state import StatesGroup, State
+
 
 class ParentReg(StatesGroup):
     waiting_parent_name = State()
     confirm_parent = State()
+
 
 class ChildReg(StatesGroup):
     waiting_child_name = State()
     confirm_child_name = State()
     choose_class = State()
     confirm_child_all = State()
-
-
-class Order(StatesGroup):
-    choose_child = State()


### PR DESCRIPTION
## Summary
- Remove old order link flow from UA handlers
- Extract `OrderStates` to `states/order_states.py`
- Route "Замовлення" command through new order router

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c02bafc0088323bdee48d9195a7f0c