### PR TITLE
feat: dynamic week selection and menu preview

### DIFF
--- a/tests/test_order_flow.py
+++ b/tests/test_order_flow.py
@@ -17,6 +17,7 @@ from handlers.order import (
     confirm_order,
 )
 from keyboards.common import ChildCB, ConfirmCB
+from week_config import WEEKS, get_week_menu
 
 
 class DummyMessage:
@@ -105,7 +106,8 @@ def test_confirmation_text(monkeypatch):
         cb = DummyCallbackQuery("dm_0_0", message)
         await day_meal_chosen(cb, fsm)
 
-        assert message.answers[-1] == f"<b>{order.WEEKS[0][0]}</b>\\n{order.DAYS[0]} — {order.MEALS[0]}"
+        assert message.answers[-2] == get_week_menu(0)
+        assert message.answers[-1] == f"<b>{WEEKS[0][0]}</b>\\n{order.DAYS[0]} — {order.MEALS[0]}"
 
     asyncio.run(scenario())
 

--- a/week_config.py
+++ b/week_config.py
@@ -1,0 +1,45 @@
+import os
+from datetime import date, datetime, timedelta
+from typing import List, Tuple
+
+START_DATE = date(2025, 9, 1)
+
+
+def build_weeks(count: int = 4) -> List[Tuple[str, str]]:
+    weeks: List[Tuple[str, str]] = []
+    for i in range(count):
+        start = START_DATE + timedelta(weeks=i)
+        end = start + timedelta(days=4)
+        label = f"Тиждень {i + 1}"
+        weeks.append((label, f"{start.strftime('%d.%m.%Y')} – {end.strftime('%d.%m.%Y')}"))
+    return weeks
+
+
+WEEKS = build_weeks()
+
+WEEK_MENUS = {
+    0: "Меню тижня 1: Страва A, Страва B",
+    1: "Меню тижня 2: Страва C, Страва D",
+    2: "Меню тижня 3: Страва E, Страва F",
+    3: "Меню тижня 4: Страва G, Страва H",
+}
+
+
+def get_current_week(today: date | None = None) -> int:
+    override = os.getenv("WEEK_OVERRIDE")
+    if override and override.isdigit():
+        idx = int(override)
+        return max(0, min(idx, len(WEEKS) - 1))
+    if today is None:
+        today = date.today()
+    for i, (_, rng) in enumerate(WEEKS):
+        start_str, end_str = rng.split(" – ")
+        start = datetime.strptime(start_str, "%d.%m.%Y").date()
+        end = datetime.strptime(end_str, "%d.%m.%Y").date()
+        if start <= today <= end:
+            return i
+    return 0
+
+
+def get_week_menu(index: int) -> str:
+    return WEEK_MENUS.get(index, "Меню недоступне")


### PR DESCRIPTION
## Summary
- compute week list dynamically with `get_current_week` and optional override
- show full weekly menu after choosing day and meal
- adjust tests for new week handling and menu preview

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03514e05883238aa7727549ee6628